### PR TITLE
Launching the Model Manager when Shift+click

### DIFF
--- a/loader/enterLoader.js
+++ b/loader/enterLoader.js
@@ -68,7 +68,7 @@ function styleInit() {
 function popUpReg() {
   let f = LGraphCanvas.prototype.processNodeWidgets;
   function processNodeWidgets(node, pos, event, active_widget) {
-    if (!event.shiftKey && event.type === LiteGraph.pointerevents_method + "down") {
+    if (event.shiftKey && event.type === LiteGraph.pointerevents_method + "down") {
       if (!node.widgets || !node.widgets.length || (!this.allow_interaction && !node.flags.allow_interaction)) {
         return null;
       }


### PR DESCRIPTION
Thanks for the great work! 

Currently, when the user clicks on a model list, the model manager is launched, and to use the existing list, the user has to shift+left click. However, this makes it inconvenient to use other loaders such as vae or controlnet, so I propose to do the opposite and only launch the model list when shift+clicked. 